### PR TITLE
Fix lidar observation rotatePitch behavior

### DIFF
--- a/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Access/IMixinMixinVec3drotatePitchLidar.java
+++ b/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Access/IMixinMixinVec3drotatePitchLidar.java
@@ -1,0 +1,7 @@
+package com.microsoft.Malmo.Access;
+
+import net.minecraft.util.math.Vec3d;
+
+public interface IMixinMixinVec3drotatePitchLidar {
+    public Vec3d rotatePitchLidar(float pitch);
+}

--- a/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinVec3d.java
+++ b/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Mixins/MixinVec3d.java
@@ -1,0 +1,43 @@
+package com.microsoft.Malmo.Mixins;
+
+import com.microsoft.Malmo.Access.IMixinMixinVec3drotatePitchLidar;
+
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.MathHelper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+
+@Mixin(Vec3d.class)
+public abstract class MixinVec3d implements IMixinMixinVec3drotatePitchLidar{
+
+    @Shadow public double xCoord;
+    @Shadow public double yCoord;
+    @Shadow public double zCoord;
+
+    @Override
+    public Vec3d rotatePitchLidar(float pitch)
+    {   
+        float pitch_radian;
+        float pitch_degree = pitch * (float)180.0 / (float)Math.PI;
+        double x = this.xCoord;
+        double z = this.zCoord;
+        float origin_pitch_degree = (float)MathHelper.atan2(this.yCoord, MathHelper.sqrt(x*x + z*z)) * (float)180.0 / (float)Math.PI;
+        if (origin_pitch_degree + pitch_degree > 89){
+            pitch_radian = 89 / (float)180.0 * (float)Math.PI;
+        } else if (origin_pitch_degree + pitch_degree < -89){
+            pitch_radian = -89 / (float)180.0 * (float)Math.PI;
+        } else {
+            pitch_radian = (origin_pitch_degree + pitch_degree) / (float)180.0 * (float)Math.PI;
+        }
+        float f = MathHelper.sin(pitch_radian)/MathHelper.cos(pitch_radian);
+        double y = (double)f * MathHelper.sqrt(x*x + z*z);
+        double ratio = 1.0 / MathHelper.sqrt(y*y + x*x + z*z);
+        double d0 = ratio * x;
+        double d1 = ratio * y;
+        double d2 = ratio * z;
+        return new Vec3d(d0, d1, d2);
+    }
+}

--- a/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/JSONWorldDataHelper.java
+++ b/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Utils/JSONWorldDataHelper.java
@@ -49,6 +49,8 @@ import java.util.*;
 
 import static com.microsoft.Malmo.MissionHandlers.ObservationFromRayImplementation.findEntity;
 
+import com.microsoft.Malmo.Access.IMixinMixinVec3drotatePitchLidar;
+
 /**
  * Helper class for building the "World data" to be passed from Minecraft back to the agent.<br>
  * This class contains helper methods to build up a JSON tree of useful information, such as health, XP, food levels, distance travelled, etc.etc.<br>
@@ -409,8 +411,8 @@ public class JSONWorldDataHelper
     public static List<Tuple<RayOffset, Vec3d>> getDirectedRays(List<RayOffset> rays, Vec3d playerLookVec) {
         List<Tuple<RayOffset, Vec3d>> directedRays = new ArrayList<>();
         for (RayOffset ray : rays) {
-            directedRays.add(new Tuple<>(ray, playerLookVec
-                    .rotatePitch(ray.getPitch())
+            directedRays.add(new Tuple<>(ray, ((IMixinMixinVec3drotatePitchLidar) (Object) playerLookVec)
+                    .rotatePitchLidar(ray.getPitch())
                     .rotateYaw(ray.getYaw())
                     .scale(ray.getDistance())));
         }

--- a/minedojo/sim/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
+++ b/minedojo/sim/Malmo/Minecraft/src/main/resources/mixins.overclocking.malmomod.json
@@ -16,7 +16,8 @@
     "MixinMergeStatsFix",
     "MixinForgeHookStatsFix",
     "MixinItemFood",
-    "MixinItemBucketMilk"
+    "MixinItemBucketMilk",
+    "MixinVec3d"
   ],
   "server": [],
   "client": [


### PR DESCRIPTION
The default rotatePitch for lidar rays was not consistent with the rotate pitch action in the agent's action space.

Now a new rotatePitchLidar replaces the previous rotatePitch for lidar observation to make this consistent. In the new 

The new rotatePitchLidar treats the lidar rotate space as a globe, where delta yaw represents the change in longitude and delta pitch represents the change in latitude. It has the following steps:
1. Read the agent's current look vector in 3D coordinates.
2. Calculate the agent's current pitch using the arc tangent function between the look vector's length in the y coordinate and the length of its projection on the x-z plane. (curr_pitch = atan2(y, sqrt(x*2 + z^2))
3. Obtain the target pitch by adding the current pitch and the given delta pitch together. The target pitch is bounded between -89 and 89 degrees because the actual bounds, -90 and 90 degrees, may cause potential division by zero error.
4. Calculate the new y coordinate value by new_y = tan(target_pitch) * sqrt(x*2 + z^2). Make use of the tangent value and the length of the look vector's x-z plane projection.
5. Normalize the new y, x, and z values to make the length of the new look vector equal to one and return the new vector.
