### PR TITLE
:bug: Fix gradle path on m1 mac

### DIFF
--- a/minedojo/sim/Malmo/Minecraft/build.gradle
+++ b/minedojo/sim/Malmo/Minecraft/build.gradle
@@ -306,7 +306,7 @@ task jaxb() {
     description 'Generate source files for our XML schemas using JAXB'
 
     // Create an index file listing all the schemas:
-    def schemaIndexFile = new File('src/main/resources/schemas.index')
+    def schemaIndexFile = new File("$projectDir/src/main/resources/schemas.index")
     def contents = ""
     def tree = copySchemas.source
     tree.visit { fileDetails ->


### PR DESCRIPTION
> Be careful about using pure relative paths in Gradle build scripts; those rely on the working directory at the time the build is invoked, which isn't something you should depend on. It's much better to ground your paths against $projectDir or $rootDir.

https://stackoverflow.com/a/27948668/8614565

And it fixes java.io.FileNotFoundException: src/main/resources/schemas.index (No such file or directory)

On M1 mac build system.