### PR TITLE
Work around broken ForgeGradle fetch

### DIFF
--- a/minedojo/sim/Malmo/Minecraft/build.gradle
+++ b/minedojo/sim/Malmo/Minecraft/build.gradle
@@ -22,7 +22,7 @@ buildscript {
             exclude group: 'org.ow2.asm', module: 'asm-debug-all'
         }
 
-        classpath 'com.github.yunfanjiang:ForgeGradle:FG_2.2_patched-SNAPSHOT'
+        classpath 'com.github.claucambra:ForgeGradle:FG_2.2_patched-SNAPSHOT'
     }
     configurations {
         compileClasspath {
@@ -42,7 +42,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'com.github.yunfanjiang:ForgeGradle:FG_2.2_patched-SNAPSHOT'
+    implementation 'com.github.claucambra:ForgeGradle:FG_2.2_patched-SNAPSHOT'
 }
 
 apply plugin: 'net.minecraftforge.gradle.forge'


### PR DESCRIPTION
Hi, in order to fix #77 I created a fork of ForgeGradle and replaced the reference to @yunfanjiang's fork in `build.gradle` with mine. 

This fixes the issue fetching from JitPack for me. Though this might not be the optimal solution (looking at the commit history it seems the same workaround has been used before) it seems to work in the mean time :)