### PR TITLE
Update English Minecraft wiki links

### DIFF
--- a/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
+++ b/minedojo/sim/Malmo/Minecraft/src/main/java/com/microsoft/Malmo/Server/ServerStateMachine.java
@@ -849,7 +849,7 @@ public class ServerStateMachine extends StateMachine
             attribute.removeModifier(modifier_id);
             double toAdd = maxHealth - attribute.getAttributeValue();
             // Note: the last argument being 0 means that this is an addition modifier.
-            // See https://minecraft.gamepedia.com/Attribute#Modifiers
+            // See https://minecraft.wiki/w/Attribute#Modifiers
             attribute.applyModifier(new AttributeModifier(modifier_id, "Set Max Health", toAdd, 0));
         }
 

--- a/minedojo/sim/Malmo/Schemas/MissionHandlers.xsd
+++ b/minedojo/sim/Malmo/Schemas/MissionHandlers.xsd
@@ -214,7 +214,7 @@
 
                         If left blank, the world will be a normal survival world.
 
-                        Biome ID #'s can be found here: https://minecraft.gamepedia.com/Biome#Biome_IDs
+                        Biome ID #'s can be found here: https://minecraft.wiki/w/Biome#Biome_IDs
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>

--- a/minedojo/sim/handlers/agent/observations/lifestats.py
+++ b/minedojo/sim/handlers/agent/observations/lifestats.py
@@ -97,7 +97,7 @@ class _ArmorObservation(LifeStatsObservation):
 class _FoodObservation(LifeStatsObservation):
     """
     Handles food_level observation representing the player's current hunger level, shown on the hunger bar. Its initial
-    value on world creation is 20 (full bar) - https://minecraft.gamepedia.com/Hunger#Mechanics
+    value on world creation is 20 (full bar) - https://minecraft.wiki/w/Hunger#Mechanics
     """
 
     def __init__(self):
@@ -118,7 +118,7 @@ class _SaturationObservation(LifeStatsObservation):
     """
     Returns the food saturation observation which determines how fast the hunger level depletes and is controlled by the
     kinds of food the player has eaten. Its maximum value always equals foodLevel's value and decreases with the hunger
-    level. Its initial value on world creation is 5. - https://minecraft.gamepedia.com/Hunger#Mechanics
+    level. Its initial value on world creation is 5. - https://minecraft.wiki/w/Hunger#Mechanics
     """
 
     def __init__(self):
@@ -140,7 +140,7 @@ class _SaturationObservation(LifeStatsObservation):
 class _XPObservation(LifeStatsObservation):
     """
     Handles observation of experience points 1395 experience corresponds with level 30
-    - see https://minecraft.gamepedia.com/Experience for more details
+    - see https://minecraft.wiki/w/Experience for more details
     """
 
     def __init__(self):

--- a/minedojo/sim/handlers/server/world.py
+++ b/minedojo/sim/handlers/server/world.py
@@ -18,7 +18,7 @@ class DefaultWorldGenerator(Handler):
 
     Args:
         force_reset (bool, optional): If the world should be reset every episode.. Defaults to True.
-        world_seed: https://minecraft.fandom.com/wiki/Seed_(level_generation)
+        world_seed: https://minecraft.wiki/w/Seed_(level_generation)
 
     Example usage:
 

--- a/minedojo/sim/mc_meta/mc.py
+++ b/minedojo/sim/mc_meta/mc.py
@@ -746,7 +746,7 @@ def strip_item_prefix(minecraft_name):
     return minecraft_name
 
 
-# Transcribed from: https://minecraft.gamepedia.com/index.php?title=Biome&oldid=1057817,
+# Transcribed from: https://minecraft.wiki/w/index.php?title=Biome&oldid=1057817,
 #   which has the biomes as they were during the minecraft version at the time: 1.11.2
 # _m indicates that the terrain is more mountainous
 # _f indicates that the terrain has trees where the base biome does not.

--- a/minedojo/sim/sim.py
+++ b/minedojo/sim/sim.py
@@ -91,7 +91,7 @@ class MineDojoSim(gym.Env):
 
         start_time: If not ``None``, specifies the time when the agent spawns.
                 If supplied, should be an int between 0 and 24000.
-                See `here <https://minecraft.fandom.com/wiki/Daylight_cycle>`_ for more information.
+                See `here <https://minecraft.wiki/w/Daylight_cycle>`_ for more information.
                 Default: ``None``.
 
         use_depth: If ``True``, includes depth map in observations.
@@ -113,7 +113,7 @@ class MineDojoSim(gym.Env):
 
         world_seed: Seed for deterministic world generation
                 if ``generate_world_type`` is ``"default"`` or ``"specified_biome"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 

--- a/minedojo/tasks/meta/combat.py
+++ b/minedojo/tasks/meta/combat.py
@@ -116,7 +116,7 @@ class CombatMeta(ExtraSpawnMetaTaskBase):
 
         world_seed: Seed for deterministic world generation
                 if ``generate_world_type`` is ``"default"`` or ``"specified_biome"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 

--- a/minedojo/tasks/meta/creative/creative.py
+++ b/minedojo/tasks/meta/creative/creative.py
@@ -72,7 +72,7 @@ class CreativeMeta(MetaTaskBase):
 
         world_seed: Seed for deterministic world generation
                 if ``generate_world_type`` is ``"default"`` or ``"specified_biome"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 

--- a/minedojo/tasks/meta/harvest.py
+++ b/minedojo/tasks/meta/harvest.py
@@ -109,7 +109,7 @@ class HarvestMeta(ExtraSpawnMetaTaskBase):
                 Default: ``None``.
 
         world_seed: The seed for generating a minecraft world if ``generate_world_type`` is ``"default"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 

--- a/minedojo/tasks/meta/playthrough.py
+++ b/minedojo/tasks/meta/playthrough.py
@@ -86,7 +86,7 @@ class Playthrough(MetaTaskBase):
 
         world_seed: Seed for deterministic world generation
                 if ``generate_world_type`` is ``"default"`` or ``"specified_biome"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 

--- a/minedojo/tasks/meta/survival.py
+++ b/minedojo/tasks/meta/survival.py
@@ -79,7 +79,7 @@ class SurvivalMeta(MetaTaskBase):
 
         world_seed: Seed for deterministic world generation
                 if ``generate_world_type`` is ``"default"`` or ``"specified_biome"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 

--- a/minedojo/tasks/meta/tech_tree.py
+++ b/minedojo/tasks/meta/tech_tree.py
@@ -148,7 +148,7 @@ class TechTreeMeta(ExtraSpawnMetaTaskBase):
 
         world_seed: Seed for deterministic world generation
                 if ``generate_world_type`` is ``"default"`` or ``"specified_biome"``.
-                See `here <https://minecraft.fandom.com/wiki/Seed_(level_generation)>`_ for more details.
+                See `here <https://minecraft.wiki/w/Seed_(level_generation)>`_ for more details.
                 Default: ``None``.
     """
 


### PR DESCRIPTION
The English Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all English "legacy" wiki URLs accordingly.