### PR TITLE
Fix validate install for fresh install from pip

### DIFF
--- a/minedojo/sim/spaces.py
+++ b/minedojo/sim/spaces.py
@@ -490,7 +490,7 @@ class MultiDiscrete(gym.spaces.MultiDiscrete, MineRLSpace):
     def sample(self, bs=None):
         bdim = () if bs is None else (bs,)
         return (
-            self.np_random.random_sample(bdim + self.nvec.shape) * self.nvec
+            self.np_random.random_sample(*(bdim + self.nvec.shape)) * self.nvec
         ).astype(self.dtype)
 
 

--- a/minedojo/sim/wrappers/ar_nn/ar_masks_wrapper.py
+++ b/minedojo/sim/wrappers/ar_nn/ar_masks_wrapper.py
@@ -15,10 +15,10 @@ class ARMasksWrapper(gym.ObservationWrapper):
         env: Union[MineDojoSim, gym.Wrapper],
         action_categories_and_num_args: Optional[dict[str, int]] = None,
     ):
-        assert "inventory" in env.observation_space.keys()
-        assert "nearby_tools" in env.observation_space.keys()
-        assert "table" in env.observation_space["nearby_tools"].keys()
-        assert "furnace" in env.observation_space["nearby_tools"].keys()
+        assert "inventory" in list(env.observation_space.keys())
+        assert "nearby_tools" in list(env.observation_space.keys())
+        assert "table" in list(env.observation_space["nearby_tools"].keys())
+        assert "furnace" in list(env.observation_space["nearby_tools"].keys())
         assert isinstance(
             env.action_space, spaces.MultiDiscrete
         ), "please use this wrapper with `NNActionSpaceWrapper!`"

--- a/minedojo/sim/wrappers/ar_nn/delta_inventory_wrapper.py
+++ b/minedojo/sim/wrappers/ar_nn/delta_inventory_wrapper.py
@@ -25,9 +25,9 @@ class DeltaInventoryWrapper(gym.Wrapper):
         n_decreased: int = 4,
         default_item_name: str = "air",
     ):
-        assert "inventory" in env.observation_space.keys()
-        assert "masks" in env.observation_space.keys()
-        assert "craft_smelt" in env.observation_space["masks"].keys()
+        assert "inventory" in list(env.observation_space.keys())
+        assert "masks" in list(env.observation_space.keys())
+        assert "craft_smelt" in list(env.observation_space["masks"].keys())
         assert isinstance(
             env.action_space, spaces.MultiDiscrete
         ), "please use this wrapper with `NNActionSpaceWrapper!`"

--- a/minedojo/sim/wrappers/ar_nn/nn_action_space_wrapper.py
+++ b/minedojo/sim/wrappers/ar_nn/nn_action_space_wrapper.py
@@ -21,13 +21,14 @@ class NNActionSpaceWrapper(gym.Wrapper):
         discretized_camera_interval: Union[int, float] = 15,
         strict_check: bool = True,
     ):
+        action_space_keys = list(env.action_space.keys())
         assert (
-            "equip" in env.action_space.keys()
-            and "place" in env.action_space.keys()
-            and "swap_slot" not in env.action_space.keys()
+            "equip" in action_space_keys
+            and "place" in action_space_keys
+            and "swap_slot" not in action_space_keys
         ), "please use this wrapper with event_level_control = True"
         assert (
-            "inventory" in env.observation_space.keys()
+            "inventory" in list(env.observation_space.keys())
         ), f"missing inventory from obs space"
         super().__init__(env=env)
 

--- a/minedojo/tasks/__init__.py
+++ b/minedojo/tasks/__init__.py
@@ -26,7 +26,8 @@ _logger.addHandler(_stream_handler)
 
 
 def _resource_file_path(fname) -> str:
-    with importlib_resources.path("minedojo.tasks.description_files", fname) as p:
+    with importlib_resources.as_file(
+        importlib_resources.files("minedojo.tasks.description_files") / fname) as p:
         return str(p)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
-gym==0.21.0
+gym==0.22.0
 lxml
 numpy
 coloredlogs

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ mypy-extensions
 jsonlines
 praw
 wget
-importlib_resources
+importlib_resources==6.1.1
 hydra-core
 Pillow

--- a/scripts/validate_install.py
+++ b/scripts/validate_install.py
@@ -3,17 +3,17 @@ import minedojo
 
 if __name__ == "__main__":
     env = minedojo.make(
-        task_id="combat_spider_plains_leather_armors_diamond_sword_shield",
+        task_id="open-ended",
         image_size=(288, 512),
-        world_seed=123,
+        world_seed=32,
         seed=42,
     )
 
-    print(f"[INFO] Create a task with prompt: {env.task_prompt}")
+    #print(f"[INFO] Create a task with prompt: {env.task_prompt}")
 
     env.reset()
-    for _ in range(20):
-        obs, reward, done, info = env.step(env.action_space.no_op())
+    for _ in range(1000):
+        obs, reward, done, info = env.step(env.action_space.sample())
     env.close()
 
     print("[INFO] Installation Success")

--- a/scripts/validate_install.py
+++ b/scripts/validate_install.py
@@ -3,17 +3,17 @@ import minedojo
 
 if __name__ == "__main__":
     env = minedojo.make(
-        task_id="open-ended",
+        task_id="combat_spider_plains_leather_armors_diamond_sword_shield",
         image_size=(288, 512),
-        world_seed=32,
+        world_seed=123,
         seed=42,
     )
 
-    #print(f"[INFO] Create a task with prompt: {env.task_prompt}")
+    print(f"[INFO] Create a task with prompt: {env.task_prompt}")
 
     env.reset()
-    for _ in range(1000):
-        obs, reward, done, info = env.step(env.action_space.sample())
+    for _ in range(20):
+        obs, reward, done, info = env.step(env.action_space.no_op())
     env.close()
 
     print("[INFO] Installation Success")


### PR DESCRIPTION
Hello, this PR should fix `validate_install.py` for anyone trying to install the package from pip in a new conda environment.


It bumps the `gym` version to 0.22.0. This is needed since there is a typo in `setup.py` in the 0.21.0 version of `gym`.
(the assertions were failing after I did this but this seems to be the only breaking change)

It fixes the version of `importlib_resources` since their API changed. I updated the old method to use the new API.

See #104 and #106 for the errors.
Thanks!

Closes #104 
Closes #106