### PR TITLE
Updates the usage of importlib_resources in tasks.__init__.py

### DIFF
--- a/minedojo/tasks/__init__.py
+++ b/minedojo/tasks/__init__.py
@@ -26,7 +26,8 @@ _logger.addHandler(_stream_handler)
 
 
 def _resource_file_path(fname) -> str:
-    with importlib_resources.path("minedojo.tasks.description_files", fname) as p:
+    with importlib_resources.as_file(
+        importlib_resources.files("minedojo.tasks.description_files") / fname) as p:
         return str(p)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
-gym==0.21.0
+gym==0.22.0
 lxml
 numpy
 coloredlogs


### PR DESCRIPTION
The old `importlib_resources` API has the `path` function defined. We need to migrate to the new one.

Closes #106 