### PR TITLE
Updates the usage of importlib_resources to use the files API

### DIFF
--- a/minedojo/tasks/__init__.py
+++ b/minedojo/tasks/__init__.py
@@ -26,7 +26,8 @@ _logger.addHandler(_stream_handler)
 
 
 def _resource_file_path(fname) -> str:
-    with importlib_resources.path("minedojo.tasks.description_files", fname) as p:
+    with importlib_resources.as_file(
+        importlib_resources.files("minedojo.tasks.description_files") / fname) as p:
         return str(p)
 
 


### PR DESCRIPTION
The old `importlib_resources` API has the `path` function defined. We need to migrate to the new one.

See #106 for more information.

Closes #106 