### PR TITLE
Fix malmo cannot find MixinGradle issue

### DIFF
--- a/minedojo/sim/Malmo/Minecraft/build.gradle
+++ b/minedojo/sim/Malmo/Minecraft/build.gradle
@@ -13,10 +13,11 @@ buildscript {
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+        maven { url 'https://repo.spongepowered.org/repository/maven-public/' }
     }
     dependencies {
         classpath 'org.ow2.asm:asm:6.0'
-        classpath('com.github.SpongePowered:MixinGradle:dcfaf61'){ // 0.6
+        classpath('org.spongepowered:mixingradle:0.6-SNAPSHOT'){ // 0.6
             // Because forgegradle requires 6.0 (not -debug-all) while mixingradle depends on 5.0
             // and putting mixin right here will place it before forge in the class loader
             exclude group: 'org.ow2.asm', module: 'asm-debug-all'


### PR DESCRIPTION
Error message:

    Starting a Gradle Daemon (subsequent builds will be faster)

    FAILURE: Build failed with an exception.

    * What went wrong: A problem occurred configuring root project 'Minecraft'.
    > Could not resolve all artifacts for configuration ':classpath'.
       > Could not find com.github.SpongePowered:MixinGradle:dcfaf61.
         Searched in the following locations:
           - https://jitpack.io/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.pom
           - https://jitpack.io/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.jar - https://jcenter.bintray.com/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.pom - https://jcenter.bintray.com/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.jar - https://repo.maven.apache.org/maven2/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.pom - https://repo.maven.apache.org/maven2/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.jar - https://maven.minecraftforge.net/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.pom - https://maven.minecraftforge.net/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.jar - https://oss.sonatype.org/content/repositories/snapshots/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.pom - https://oss.sonatype.org/content/repositories/snapshots/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.jar - https://plugins.gradle.org/m2/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.pom - https://plugins.gradle.org/m2/com/github/SpongePowered/MixinGradle/dcfaf61/MixinGradle-dcfaf61.jar Required by: project :

Reference: https://github.com/microsoft/malmo/issues/942#issuecomment-2058351409